### PR TITLE
fix: add strategy picker for crisis mode with multiple active crises

### DIFF
--- a/src/app/(app)/crisis/page.tsx
+++ b/src/app/(app)/crisis/page.tsx
@@ -7,9 +7,10 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { CrisisIntakeForm } from "@/components/features/crisis/crisis-intake-form";
 import { CrisisWarRoom } from "@/components/features/crisis/crisis-war-room";
+import { CrisisStrategyPicker } from "@/components/features/crisis/crisis-strategy-picker";
 import { CrisisDone } from "@/components/features/crisis/crisis-done";
 import { cn } from "@/lib/utils";
-import type { CrisisPlan, CrisisFileAttachment, PanicLevel } from "@/types";
+import type { CrisisPlan, CrisisStrategy, CrisisFileAttachment, PanicLevel } from "@/types";
 
 // -------------------------------------------------------
 // Types
@@ -29,8 +30,16 @@ type Phase =
   | "dashboard"       // list of all active sessions
   | "intake"          // new crisis form
   | "generating"      // AI generating plan
+  | "strategy"        // pick from multiple strategy options
   | "active"          // war room for a specific plan
   | "done";           // just completed a plan
+
+interface StrategyPickerState {
+  strategies: CrisisStrategy[];
+  taskName: string;
+  deadline: string;
+  completionPct: number;
+}
 
 // -------------------------------------------------------
 // Helpers
@@ -80,6 +89,7 @@ export default function CrisisPage() {
   const [intakeError, setIntakeError] = useState<string | null>(null);
   const [completedTaskName, setCompletedTaskName] = useState<string | null>(null);
   const [abandoningId, setAbandoningId] = useState<string | null>(null);
+  const [strategyState, setStrategyState] = useState<StrategyPickerState | null>(null);
 
   // -------------------------------------------------------
   // Load all active plans
@@ -153,6 +163,19 @@ export default function CrisisPage() {
       }
 
       const body = await res.json();
+
+      // AI returned multiple strategies — let the user pick
+      if (body.strategies) {
+        setStrategyState({
+          strategies: body.strategies,
+          taskName: data.taskName,
+          deadline: data.deadline,
+          completionPct: data.completionPct,
+        });
+        setPhase("strategy");
+        return;
+      }
+
       const newPlan: ActivePlanData = {
         id: body.id,
         taskName: data.taskName,
@@ -194,6 +217,48 @@ export default function CrisisPage() {
     }
   }
 
+  async function handleStrategySelect(strategy: CrisisStrategy) {
+    if (!strategyState) return;
+    setPhase("generating");
+
+    try {
+      const res = await fetch("/api/crisis", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          taskName: strategyState.taskName,
+          deadline: strategyState.deadline,
+          completionPct: strategyState.completionPct,
+          selectedPlan: strategy.plan,
+        }),
+      });
+
+      if (!res.ok) {
+        const body = await res.json();
+        throw new Error(body.error ?? "Failed to save crisis plan");
+      }
+
+      const body = await res.json();
+      const newPlan: ActivePlanData = {
+        id: body.id,
+        taskName: strategyState.taskName,
+        deadline: new Date(strategyState.deadline).toISOString(),
+        panicLevel: body.plan.panicLevel,
+        panicLabel: body.plan.panicLabel,
+        plan: { ...body.plan, currentTaskIndex: body.plan.currentTaskIndex ?? 0 },
+      };
+
+      setActivePlan(newPlan);
+      setPlans((prev) => [newPlan, ...prev]);
+      setStrategyState(null);
+      setPhase("active");
+    } catch (err) {
+      setIntakeError(err instanceof Error ? err.message : "Something went wrong");
+      setStrategyState(null);
+      setPhase("intake");
+    }
+  }
+
   function handleDoneNext() {
     // After completing, go to dashboard if there are remaining plans, else new intake
     setPhase(plans.length > 0 ? "dashboard" : "intake");
@@ -217,6 +282,17 @@ export default function CrisisPage() {
       <div className="flex min-h-[40vh] flex-col items-center justify-center gap-3">
         <Loader2 className="h-8 w-8 animate-spin text-primary" />
         <p className="text-lg font-medium">Reading the situation...</p>
+      </div>
+    );
+  }
+
+  if (phase === "strategy" && strategyState) {
+    return (
+      <div className="mx-auto max-w-lg space-y-4">
+        <CrisisStrategyPicker
+          strategies={strategyState.strategies}
+          onSelect={handleStrategySelect}
+        />
       </div>
     );
   }

--- a/src/app/api/crisis/route.ts
+++ b/src/app/api/crisis/route.ts
@@ -19,7 +19,7 @@ import { getUser } from "@/lib/db/queries";
 import { db } from "@/lib/db";
 import { crisisPlans } from "@/lib/db/schema";
 import { eq, and } from "drizzle-orm";
-import type { CrisisFileAttachment, CrisisTask } from "@/types";
+import type { CrisisFileAttachment, CrisisPlan, CrisisTask } from "@/types";
 
 const TIME_FORMAT_OPTS: Intl.DateTimeFormatOptions = {
   weekday: "short",
@@ -185,11 +185,13 @@ export async function POST(request: Request) {
       deadline,
       completionPct,
       files,
+      selectedPlan,
     } = body as {
       taskName: string;
       deadline: string;
       completionPct: number;
       files?: CrisisFileAttachment[];
+      selectedPlan?: CrisisPlan;
     };
 
     if (!taskName?.trim()) {
@@ -197,6 +199,33 @@ export async function POST(request: Request) {
     }
     if (!deadline) {
       return NextResponse.json({ error: "deadline is required" }, { status: 400 });
+    }
+
+    // If the user selected a strategy from a previous multi-strategy response,
+    // persist it directly without calling AI again.
+    if (selectedPlan) {
+      const deadlineDate = new Date(deadline);
+      const saved = await createCrisisPlan({
+        userId,
+        taskName,
+        deadline: deadlineDate,
+        completionPct,
+        panicLevel: selectedPlan.panicLevel,
+        panicLabel: selectedPlan.panicLabel,
+        summary: selectedPlan.summary,
+        tasks: selectedPlan.tasks,
+      });
+
+      return NextResponse.json({
+        id: saved.id,
+        plan: {
+          panicLevel: saved.panicLevel,
+          panicLabel: saved.panicLabel,
+          summary: saved.summary,
+          tasks: saved.tasks,
+          currentTaskIndex: saved.currentTaskIndex,
+        },
+      });
     }
 
     const now = new Date();
@@ -238,7 +267,7 @@ export async function POST(request: Request) {
     // Build commute context from user's current location
     const commuteContext = buildCommuteContext(userLocation, allCommutes, await getSavedLocations(userId));
 
-    const plan = await getCrisisPlan({
+    const result = await getCrisisPlan({
       taskName,
       deadline: deadlineDate.toLocaleString("en-US", { timeZone: timezone, ...TIME_FORMAT_OPTS }),
       completionPct,
@@ -258,6 +287,16 @@ export async function POST(request: Request) {
       files,
     });
 
+    // Multi-strategy response — return strategies for user to pick from
+    if (result.type === "strategies") {
+      return NextResponse.json({
+        strategies: result.strategies,
+        // Pass through context the frontend needs to persist after selection
+        _context: { taskName, deadline: deadlineDate.toISOString(), completionPct },
+      });
+    }
+
+    const plan = result.plan;
     const saved = await createCrisisPlan({
       userId,
       taskName,
@@ -360,7 +399,7 @@ export async function PUT(request: Request) {
     const completedTasks = existingTasks.slice(0, taskIndex);
     const completedStepTitles = completedTasks.map((t) => t.title);
 
-    const newPlan = await getCrisisPlan({
+    const result = await getCrisisPlan({
       taskName: plan.taskName,
       deadline: deadlineDate.toLocaleString("en-US", { timeZone: timezone, ...TIME_FORMAT_OPTS }),
       completionPct: effectiveCompletion,
@@ -379,6 +418,12 @@ export async function PUT(request: Request) {
       currentLocation: userLocation?.matchedLocationName ?? null,
       commuteContext,
     });
+
+    // Reassess always uses a single plan — if AI returned strategies, pick the first one
+    const newPlan: CrisisPlan =
+      result.type === "strategies"
+        ? result.strategies[0].plan
+        : result.plan;
 
     // Merge: completed tasks stay, AI-generated tasks replace the remaining ones
     const mergedTasks = [...completedTasks, ...newPlan.tasks];

--- a/src/components/features/crisis/crisis-strategy-picker.tsx
+++ b/src/components/features/crisis/crisis-strategy-picker.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { ChevronRight, Clock } from "lucide-react";
+import type { CrisisStrategy, PanicLevel } from "@/types";
+
+interface Props {
+  strategies: CrisisStrategy[];
+  onSelect: (strategy: CrisisStrategy) => void;
+}
+
+function panicColor(level: PanicLevel) {
+  if (level === "damage-control") return "border-destructive/40 bg-destructive/5";
+  if (level === "tight") return "border-amber-500/40 bg-amber-500/5";
+  return "border-emerald-500/40 bg-emerald-500/5";
+}
+
+function panicBadgeVariant(level: PanicLevel): "destructive" | "secondary" | "default" {
+  if (level === "damage-control") return "destructive";
+  if (level === "tight") return "secondary";
+  return "default";
+}
+
+function totalMinutes(strategy: CrisisStrategy): number {
+  return strategy.plan.tasks.reduce((sum, t) => sum + t.estimatedMinutes, 0);
+}
+
+function formatTime(minutes: number): string {
+  if (minutes < 60) return `${minutes}m`;
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}
+
+export function CrisisStrategyPicker({ strategies, onSelect }: Props) {
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold">Pick your approach</h2>
+        <p className="text-sm text-muted-foreground">
+          You&apos;re juggling multiple crises. How do you want to handle this one?
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        {strategies.map((strategy, i) => {
+          const isSelected = selectedIndex === i;
+          const time = totalMinutes(strategy);
+
+          return (
+            <Card
+              key={i}
+              className={cn(
+                "cursor-pointer transition-all",
+                panicColor(strategy.plan.panicLevel),
+                isSelected
+                  ? "ring-2 ring-primary ring-offset-2 ring-offset-background"
+                  : "hover:bg-accent/30"
+              )}
+              onClick={() => setSelectedIndex(i)}
+            >
+              <CardContent className="p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="font-semibold">{strategy.label}</p>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      {strategy.description}
+                    </p>
+                  </div>
+                  <Badge variant={panicBadgeVariant(strategy.plan.panicLevel)}>
+                    {strategy.plan.panicLabel}
+                  </Badge>
+                </div>
+
+                <div className="mt-3 flex items-center gap-4 text-xs text-muted-foreground">
+                  <span className="flex items-center gap-1">
+                    <Clock className="h-3 w-3" />
+                    {formatTime(time)}
+                  </span>
+                  <span>{strategy.plan.tasks.length} steps</span>
+                </div>
+
+                {/* Expanded preview when selected */}
+                {isSelected && (
+                  <div className="mt-3 space-y-1.5 border-t pt-3">
+                    <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                      Steps
+                    </p>
+                    {strategy.plan.tasks.map((task, ti) => (
+                      <div
+                        key={ti}
+                        className="flex items-center gap-2 text-sm"
+                      >
+                        <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-medium">
+                          {ti + 1}
+                        </span>
+                        <span className="truncate">{task.title}</span>
+                        <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+                          ~{task.estimatedMinutes}m
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+
+      <Button
+        className="w-full"
+        disabled={selectedIndex === null}
+        onClick={() => selectedIndex !== null && onSelect(strategies[selectedIndex])}
+      >
+        Lock in this approach
+        <ChevronRight className="ml-1 h-4 w-4" />
+      </Button>
+    </div>
+  );
+}

--- a/src/lib/ai/crisis.ts
+++ b/src/lib/ai/crisis.ts
@@ -1,7 +1,7 @@
 import { anthropic, callHaiku, callWithRetry } from "@/lib/ai";
 import { CRISIS_SYSTEM_PROMPT } from "@/lib/ai/prompts";
 import { extractJSON } from "@/lib/ai/validate";
-import type { CrisisPlan, CrisisFileAttachment } from "@/types";
+import type { CrisisPlan, CrisisStrategy, CrisisFileAttachment } from "@/types";
 
 // ============================================================
 // Types
@@ -112,7 +112,11 @@ Break this into concrete micro-tasks that fit the remaining time. Be honest abou
 // Main export
 // ============================================================
 
-export async function getCrisisPlan(params: CrisisParams): Promise<CrisisPlan> {
+export type CrisisResult =
+  | { type: "plan"; plan: CrisisPlan }
+  | { type: "strategies"; strategies: CrisisStrategy[] };
+
+export async function getCrisisPlan(params: CrisisParams): Promise<CrisisResult> {
   const userPromptText = buildUserPrompt(params);
 
   try {
@@ -174,27 +178,45 @@ export async function getCrisisPlan(params: CrisisParams): Promise<CrisisPlan> {
     }
 
     // Try standard extraction first; fall back to bracket-scanning if that fails
-    let parsed: CrisisPlan;
+    let parsed: Record<string, unknown>;
     try {
-      parsed = extractJSON<CrisisPlan>(responseText);
+      parsed = extractJSON<Record<string, unknown>>(responseText);
     } catch {
       // extractJSON failed — try finding the outermost { ... } in the response
       const start = responseText.indexOf("{");
       const end = responseText.lastIndexOf("}");
       if (start === -1 || end === -1 || end <= start) {
         console.error("[AI] Crisis: no JSON object found in response:", responseText);
-        return FALLBACK_PLAN;
+        return { type: "plan", plan: FALLBACK_PLAN };
       }
       try {
-        parsed = JSON.parse(responseText.slice(start, end + 1)) as CrisisPlan;
+        parsed = JSON.parse(responseText.slice(start, end + 1)) as Record<string, unknown>;
       } catch (innerErr) {
         console.error("[AI] Crisis: bracket-scan parse failed:", innerErr, "\nRaw:", responseText);
-        return FALLBACK_PLAN;
+        return { type: "plan", plan: FALLBACK_PLAN };
       }
     }
-    return parsed;
+
+    // Determine if the AI returned strategies or a single plan
+    if (Array.isArray(parsed.strategies) && parsed.strategies.length > 0) {
+      const strategies: CrisisStrategy[] = parsed.strategies.map(
+        (s: Record<string, unknown>) => ({
+          label: String(s.label ?? "Strategy"),
+          description: String(s.description ?? ""),
+          plan: {
+            panicLevel: s.panicLevel as CrisisPlan["panicLevel"],
+            panicLabel: String(s.panicLabel ?? ""),
+            summary: String(s.summary ?? ""),
+            tasks: (s.tasks as CrisisPlan["tasks"]) ?? [],
+          },
+        })
+      );
+      return { type: "strategies", strategies };
+    }
+
+    return { type: "plan", plan: parsed as unknown as CrisisPlan };
   } catch (error) {
     console.error("[AI] Crisis: unexpected error:", error);
-    return FALLBACK_PLAN;
+    return { type: "plan", plan: FALLBACK_PLAN };
   }
 }

--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -605,6 +605,8 @@ Break the task into 5-8 concrete micro-tasks (≤30 min each) that fit the avail
 - If the user has attached files (assignment instructions, rubrics, screenshots), use them to make the micro-tasks more specific and accurate to the actual requirements.
 - Every instruction should be specific enough to start immediately. BAD: "Work on the main section." GOOD: "Open your doc. Write 3 paragraphs covering [specific topic]. Aim for 500 words. Skip perfection — get ideas down."
 - stuckHint should address the most likely freeze point for that step.
+- SINGLE CRISIS: ALWAYS commit to ONE strategy. Never present multiple options or alternative paths. Pick the best approach for the situation and build every task around it. The user is in crisis — choosing between strategies is cognitive load they cannot afford right now. If you see two viable approaches, pick the one most likely to produce a passable result in the available time and go all-in on it. Use the standard output schema.
+- MULTIPLE ACTIVE CRISES: When the user has other active crisis plans, use the STRATEGIES output schema instead. Present exactly 2-3 distinct strategic approaches (e.g. "Finish essay first, then lab report" vs "Alternate: 1 hour on each" vs "Triage: submit what you have for essay, focus on lab report"). Each strategy gets its own complete task list. Let the user decide how to allocate their limited time.
 
 ## CRITICAL: Anti-Hallucination Rules
 1. TIME MATH: Use the "actual work time" from the time budget (which already subtracts events and sleep). All micro-task estimatedMinutes MUST sum to ≤ actual work time. If they won't fit, drop the lowest-value tasks and note what was cut in the summary. NEVER schedule tasks during sleep hours unless the user explicitly says they're pulling an all-nighter.
@@ -618,7 +620,9 @@ Break the task into 5-8 concrete micro-tasks (≤30 min each) that fit the avail
 5. If the user has other active crisis plans, factor in the cognitive load and time competition. Two crises with tight deadlines = damage-control.
 
 ## Output Schema
-Respond with ONLY valid JSON (no prose, no markdown):
+Respond with ONLY valid JSON (no prose, no markdown).
+
+### Standard schema (single crisis — no other active crisis plans):
 {
   "panicLevel": "fine" | "tight" | "damage-control",
   "panicLabel": "2-3 words max, e.g. 'You're fine', 'Getting tight', 'Damage control'",
@@ -629,6 +633,20 @@ Respond with ONLY valid JSON (no prose, no markdown):
       "instruction": "Specific, direct instruction they can follow immediately",
       "estimatedMinutes": 20,
       "stuckHint": "What to do if they freeze on this step"
+    }
+  ]
+}
+
+### Strategies schema (ONLY when user has other active crisis plans):
+{
+  "strategies": [
+    {
+      "label": "Short strategy name (3-5 words)",
+      "description": "1 sentence explaining this approach and its trade-offs",
+      "panicLevel": "fine" | "tight" | "damage-control",
+      "panicLabel": "2-3 words max",
+      "summary": "Honest 1-2 sentence assessment if this strategy is chosen",
+      "tasks": [ ... same task schema as above ... ]
     }
   ]
 }

--- a/src/lib/changelog.generated.json
+++ b/src/lib/changelog.generated.json
@@ -4,6 +4,10 @@
     "items": [
       {
         "type": "added",
+        "text": "Auto-estimate commute times via OSRM routing"
+      },
+      {
+        "type": "added",
         "text": "Add commute times between saved locations with crisis mode integration"
       },
       {
@@ -186,10 +190,6 @@
       {
         "type": "fixed",
         "text": "Format next event duration as human-readable and ignore distant events"
-      },
-      {
-        "type": "fixed",
-        "text": "Prevent AI from hallucinating location/event context in recommendations"
       }
     ]
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -262,6 +262,12 @@ export interface CrisisPlan {
   tasks: CrisisTask[];
 }
 
+export interface CrisisStrategy {
+  label: string;
+  description: string;
+  plan: CrisisPlan;
+}
+
 export interface CrisisFileAttachment {
   base64: string;
   mediaType:


### PR DESCRIPTION
When users have multiple active crises, the AI now returns 2-3 distinct
strategy options instead of dumping all steps into one flat list. A new
strategy picker UI lets users choose their approach before entering the
war room. Single-crisis scenarios still get a direct plan with no extra
decision step.

https://claude.ai/code/session_01F5mdWqznxSQjo7SDnAXWg3